### PR TITLE
Added a toString() call when reading the whitelist/blacklist files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config/allow_ip_list
+config/black_list

--- a/proxy.js
+++ b/proxy.js
@@ -22,10 +22,11 @@ function update_list(msg, file, mapf, collectorf) {
   fs.stat(file, function(err, stats) {
     if (!err) {
       sys.log(msg);
-      collectorf(fs.readFileSync(file)
-                   .split('\n')
+      fs.readFile(file, function(err, data) {
+        collectorf(data.toString().split("\n")
                    .filter(function(rx) { return rx.length })
                    .map(mapf));
+      });
     }
     else {
       sys.log("File '" + file + "' was not found.");
@@ -100,7 +101,6 @@ function server_cb(request, response) {
   });
   request.addListener('end', function() {
     proxy_request.end();
-    proxy_request.close();
   });
 }
 


### PR DESCRIPTION
When running this on node v0.2.5, the fs.readFileSync was returning a blog.  Adding the toString() to the result fixed the issue.  Also, changed the readFileSync to just readFile, with a callback.
