### PR TITLE
basic authentication, more advanced VHOST rules, error tolerance, redirection, multi-interface support, ...

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,8 +10,8 @@ var config = {
   allow_ip_list: './config/allow_ip_list',
   black_list:    './config/black_list',
   host_filters:   './config/hostfilters.js',
-  listen:[{ip:'91.121.154.113', port:80},
-          {ip:'2001:41d0:1:db71::1', port:80}]    
+  listen:[{ip:'0.0.0.0', port:80},//all ipv4 interfaces
+          {ip:'::', port:80}]//all ipv6 interfaces
 };
 
 exports.config = config;

--- a/config.js
+++ b/config.js
@@ -10,8 +10,8 @@ var config = {
   allow_ip_list: './config/allow_ip_list',
   black_list:    './config/black_list',
   host_filters:   './config/hostfilters.js',
-  proxy_port:    80,
-  proxy_ip:      '0.0.0.0'
+  listen:[{ip:'91.121.154.113', port:80},
+          {ip:'2001:41d0:1:db71::1', port:80}]    
 };
 
 exports.config = config;

--- a/config/readme.txt
+++ b/config/readme.txt
@@ -23,6 +23,17 @@ priority :
 1) redirect => will issue a 301 to the browser
 2) proxyto  => will lead to a "regular" reverse proxying
 3) default is to proxy
+Note that user authentication is *always* performed **before**. See bellow for 
+more informations on athentication
+
+It is also possible to specify authorization criterion. This is done using the
+"Basic" http authentication scheme as defined in RFC 2617. "Digest" is not (yet ?)
+supported. Since this reverse proxy is not seen by the useragent as a real proxy,
+we can not use proxy-authenticate. This is sad because it prevents you from dong
+http authentication on the other side as soon as you do not use the same credentials.
+Passwords SHALL be written un-encrypted at the moment.
+If you are planing on doing authentication on the application side, please do not
+use this feature as it will break it !
 
 NOTA: only http is supported, no HTTPS yet
 
@@ -32,7 +43,12 @@ example:
             "redirect": "www.google.com"
         },
         "*:80":{
-            "proxyto": "localhost:80"
+            "proxyto": "localhost:80",
+            "validuser":{
+                "admin":"pasword",
+                "user":"secret"
+            },
+            "description":"Very secret project here ;-)"
         }
     }
 

--- a/config/readme.txt
+++ b/config/readme.txt
@@ -4,10 +4,39 @@ they include:
 * allow_ip_list - a file that contains allowed ips
 * black_list    - a file that contains blocked urls (can be regexes)
 * hostfilters.js- a file that contains JSON host special actions
+
+hostfilters is used to define special actions to take. All rules are of the form
+"target host:port" => action(s)
+Currently, the proxy code tries to find a rule with the following priority :
+1) domain:port
+2) domain
+3) *:port => default rule for incomming connections to port 80
+4) *      => default rule
+5) default: proxyto what the host directive contains ;-)
+
+Please note that the rules are based on the *target* host:port located in the 
+"host" header of the http request. For example, the real target port **may** be
+different from the listening port on this server.
+
+We currently support only 2 kind of rules, they are looked up with the following 
+priority :
+1) redirect => will issue a 301 to the browser
+2) proxyto  => will lead to a "regular" reverse proxying
+3) default is to proxy
+
+NOTA: only http is supported, no HTTPS yet
+
 example:
     {
         "hostname.domain.tld": {
-            "redirect": "localhost:3001"
+            "redirect": "www.google.com"
+        },
+        "*:80":{
+            "proxyto": "localhost:80"
         }
     }
 
+
+A security preventing proxying loop is harcoded. A request that has been proxied 
+once will not be able to go thru a second time. Please let me know if this is a 
+limitation for you (jtlebi on github).

--- a/proxy.js
+++ b/proxy.js
@@ -205,8 +205,6 @@ function action_redirect(response, host){
 function action_proxy(response, request, host){
   sys.log("Proxying to " + host);
     
-  request.headers.host = host;
-  
   //launch new request
   var proxy = http.createClient(action.port, action.host);
   var proxy_request = proxy.request(request.method, request.url, request.headers);

--- a/proxy.js
+++ b/proxy.js
@@ -59,11 +59,7 @@ function update_hostfilters(){
     fs.stat(file, function(err, stats) {
     if (!err) {
       sys.log("Updating host filter");
-      fs.readFile(file, function(err, data) {
-        sys.log(file);
-        sys.log((err)?err:"");
-        sys.log(data.toString());
-        
+      fs.readFile(file, function(err, data) {        
         hostfilters = JSON.parse(data.toString());
       });
     }

--- a/proxy.js
+++ b/proxy.js
@@ -134,12 +134,17 @@ function server_cb(request, response) {
   if(!request){return;}
   
   sys.log(ip + ": " + request.method + " " + request.url);
-  //var host = request.headers['host'].split(':');
+  
+  //calc new host info
   var host = host_filter(request.headers.host);
   if(host.port!=80){request.headers.host = host.host+':'+host.port;}
   else{request.headers.host = host.host;}
+  
+  //launch new request
   var proxy = http.createClient(host.port || 80, host.host);
   var proxy_request = proxy.request(request.method, request.url, request.headers);
+  
+   //proxies to FORWARD answer to real client
   proxy_request.addListener('response', function(proxy_response) {
     proxy_response.addListener('data', function(chunk) {
       response.write(chunk, 'binary');
@@ -149,6 +154,8 @@ function server_cb(request, response) {
     });
     response.writeHead(proxy_response.statusCode, proxy_response.headers);
   });
+  
+  //proxies to SEND request to real server
   request.addListener('data', function(chunk) {
     proxy_request.write(chunk, 'binary');
   });

--- a/proxy.js
+++ b/proxy.js
@@ -251,7 +251,7 @@ function security_filter(request, response){
   if(request.headers.host === undefined ||
      request.method === undefined ||
      request.url === undefined){
-    security_log(request, response, msg);
+    security_log(request, response, "Either host, method or url is poorly defined");
     return false;
   }
   return true;

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
-Nodejs-proxy is a simple HTTP proxy server written in node.js. It currently
-just proxies all the requests on port 8080.
+Nodejs-proxy is a simple HTTP reverse proxy server written in node.js. It currently
+allows some mid-complexity to handle the reverse proxy magic take place.
 
 Nodejs-proxy was written by Peteris Krumins (peter@catonmat.net).
 His blog is at http://www.catonmat.net  --  good coders code, great reuse.
@@ -19,8 +19,9 @@ Next, run proxy.js through node program:
 
 And that's it!
 
-I have also added ip-based access control and by default the proxy will
-deny all IPs. To add a new ip, just echo it to 'allow_ip_list' file:
+I have also added ip-based access control. As long as no ip is explicitly denied,
+all will be allowed. If you need a specic access list just echo it to
+'allow_ip_list' file:
 
     $ echo '1.2.3.4' >> config/allow_ip_list
 


### PR DESCRIPTION
Hi,

On my server, i need to host mutiple services behind the same port (80) with the same IP. Some of these services are not even aware of authentication. One of these services is "Cloud9 IDE".

In this pull request, i implemented  few fancy stuffs to address these issues:
- support for multi-interface/port binding at startup
- support for redirectPermanent rules (allows to create aliases easily)
- support for basic authentication (RFC 2617)
- error managment when the target website is not responding
- better VHOST simulation with default rules support
- global exception interception. Please note that this is commented in this version of the code to ease debugging but should be de-commented in a production environnment as stated in the code.

current limitations:
- only basic authentication is supported.
- all passwords needs to be stored in clear form in the config file, it should be easy to fix.
- authentication must not be used if it is required on the target website.
- there may be crashes on "hostfilters.js" config file reload for unknown reasons.

sorry for the long list :p
