### PR TITLE
import bug fix

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -36,7 +36,7 @@ function encode_host(host){
 //config files watchers
 fs.watchFile(config.black_list,    function(c,p) { update_blacklist(); });
 fs.watchFile(config.allow_ip_list, function(c,p) { update_iplist(); });
-fs.watchFile(config.handle_proxy_routes,  function(c,p) { update_hostfilters(); });
+fs.watchFile(config.host_filters,  function(c,p) { update_hostfilters(); });
 
 
 //config files loaders/updaters
@@ -58,7 +58,7 @@ function update_list(msg, file, mapf, collectorf) {
 }
 
 function update_hostfilters(){
-    file = config.handle_proxy_routes;
+    file = config.host_filters;
     fs.stat(file, function(err, stats) {
     if (!err) {
       sys.log("Updating host filter");

--- a/proxy.js
+++ b/proxy.js
@@ -224,7 +224,7 @@ function action_proxy(response, request, host){
       response.write(chunk, 'binary');
     });
     proxy_response.addListener('end', function() {
-      response.end();
+      response.destroy();
     });
     response.writeHead(proxy_response.statusCode, proxy_response.headers);
   });


### PR DESCRIPTION
Nothing huge this time :) Just a bug fix and some cleanups

I am now using it in production on my personal blog (very low traffic) so that i now see better some bugs :)

In the original code, the connection to the original user agent is closed via "respond.end()". It seems that this call does destroy the connection object... without closing it. Strangely this bug was not visible everywhere, all the time. This is weird. Firefox for example never had issues with it but PHP, curl and wget do. Arch Linux is not affected either (really strange ???).

Anyway, replacing it with "response.destroy()" works fine. for me.
