### PR TITLE
WGET bug workaround

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -36,7 +36,7 @@ function encode_host(host){
 //config files watchers
 fs.watchFile(config.black_list,    function(c,p) { update_blacklist(); });
 fs.watchFile(config.allow_ip_list, function(c,p) { update_iplist(); });
-fs.watchFile(config.handle_proxy_routes,  function(c,p) { update_hostfilters(); });
+fs.watchFile(config.host_filters,  function(c,p) { update_hostfilters(); });
 
 
 //config files loaders/updaters
@@ -58,7 +58,7 @@ function update_list(msg, file, mapf, collectorf) {
 }
 
 function update_hostfilters(){
-    file = config.handle_proxy_routes;
+    file = config.host_filters;
     fs.stat(file, function(err, stats) {
     if (!err) {
       sys.log("Updating host filter");

--- a/proxy.js
+++ b/proxy.js
@@ -224,7 +224,7 @@ function action_proxy(response, request, host){
       response.write(chunk, 'binary');
     });
     proxy_response.addListener('end', function() {
-      response.destroy();
+      response.end();
     });
     response.writeHead(proxy_response.statusCode, proxy_response.headers);
   });

--- a/proxy.js
+++ b/proxy.js
@@ -223,15 +223,12 @@ function action_proxy(response, request, host){
   
   //proxies to FORWARD answer to real client
   proxy_request.addListener('response', function(proxy_response) {
-      
-    if(legacy_http && proxy_response.headers['Transfer-Encoding'] != undefined){
-        console.log("legacy HTTP: "+proxy_response.httpVersion);
+    if(legacy_http && proxy_response.headers['transfer-encoding'] != undefined){
+        console.log("legacy HTTP: "+request.httpVersion);
         
         //filter headers
         var headers = proxy_response.headers;
-        delete proxy_response.headers['Transfer-Encoding'];
-        response.writeHead(proxy_response.statusCode, headers);
-        
+        delete proxy_response.headers['transfer-encoding'];        
         var buffer = "";
         
         //buffer answer
@@ -239,6 +236,8 @@ function action_proxy(response, request, host){
           buffer += chunk;
         });
         proxy_response.addListener('end', function() {
+          headers['Content-length'] = buffer.length;//cancel transfer encoding "chunked"
+          response.writeHead(proxy_response.statusCode, headers);
           response.write(buffer, 'binary');
           response.end();
         });

--- a/proxy.js
+++ b/proxy.js
@@ -224,7 +224,7 @@ function action_proxy(response, request, host){
       response.write(chunk, 'binary');
     });
     proxy_response.addListener('end', function() {
-      response.end();
+      response.destroy();
     });
     response.writeHead(proxy_response.statusCode, proxy_response.headers);
   });


### PR DESCRIPTION
WGET is an HTTP1.0 client using HTTP1.1 headers. Node.js is not able to forward HTTP1.0 request and replaces them by HTTP1.1 which has the effect of enabling "transfer-encoding: chunked" by default. Sadly HTTP1.0 client doesn't support it.

This commit adds code to detect such situations. In this case, the answer is cached in memory before being forwarded to the client with the addition of "Content-length" header in order to cancel the "transfer-encoding: chunked".
