### PR TITLE
X-Forwarded-For header + better logging

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,12 +7,12 @@
 */
 
 var config = {
-  add_proxy_header: true,
+  add_proxy_header: true,//activate addition of X-Forwarded-For header for better logging on real server side
   allow_ip_list: './config/allow_ip_list',
   black_list:    './config/black_list',
   host_filters:   './config/hostfilters.js',
-  listen:[{ip:'91.121.154.113', port:80},
-          {ip:'2001:41d0:1:db71::1', port:80}]    
+  listen:[{ip:'0.0.0.0', port:80},//all ipv4 interfaces
+          {ip:'::', port:80}]//all ipv6 interfaces
 };
 
 exports.config = config;

--- a/config.js
+++ b/config.js
@@ -7,11 +7,12 @@
 */
 
 var config = {
+  add_proxy_header: true,
   allow_ip_list: './config/allow_ip_list',
   black_list:    './config/black_list',
   host_filters:   './config/hostfilters.js',
-  listen:[{ip:'0.0.0.0', port:80},//all ipv4 interfaces
-          {ip:'::', port:80}]//all ipv6 interfaces
+  listen:[{ip:'91.121.154.113', port:80},
+          {ip:'2001:41d0:1:db71::1', port:80}]    
 };
 
 exports.config = config;

--- a/proxy.js
+++ b/proxy.js
@@ -306,7 +306,6 @@ function server_cb(request, response) {
     msg = "IP " + ip + " is not allowed to use this proxy";
     action_deny(response, msg);
     security_log(request, response, msg);    
-    util.log(msg);
     return;
   }
 
@@ -314,7 +313,6 @@ function server_cb(request, response) {
     msg = "Host " + request.url + " has been denied by proxy configuration";
     action_deny(response, msg);
     security_log(request, response, msg);    
-    util.log(msg);
     return;
   }
   


### PR DESCRIPTION
Hi !

Time or another update on my side. I enhanced logging support both on the remote server side and the proxy side.

For the remote server, I added an option to handle the "X-Forwarded-For" header to let it know where to request really comes from. Of course the server will need to add the logic to read it and detect whether to trust it or not. At least, it is a "de facto" standard header. 

On the proxy side, I enhanced to output by adding the HTTP target host.
