### PR TITLE
HTTPs support

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,6 +6,8 @@
 **
 */
 
+var fs = require('fs');
+
 var config = {
   add_proxy_header: true,//activate addition of X-Forwarded-For header for better logging on real server side
   allow_ip_list: './config/allow_ip_list',
@@ -13,6 +15,23 @@ var config = {
   host_filters:   './config/hostfilters.js',
   listen:[{ip:'0.0.0.0', port:80},//all ipv4 interfaces
           {ip:'::', port:80}]//all ipv6 interfaces
+  listen_ssl:[{
+              ip:'0.0.0.0',//all *secure* ipv4 interfaces
+              port:443,
+              key:fs.readFileSync('/path/to/ssl.key'),
+              cert:fs.readFileSync('/path/to/ssl.crt'),
+              ca:[fs.readFileSync('/path/to/ca.pem'), 
+                  fs.readFileSync('/path/to/sub-ca.pem')]
+            },{ 
+              ip:'::',//all *secure* ipv6 interfaces
+              port:443,
+              key:fs.readFileSync('/path/to/ssl.key'),
+              cert:fs.readFileSync('/path/to/ssl.crt'),
+              ca:[fs.readFileSync('/path/to/ca.pem'), 
+                  fs.readFileSync('/path/to/sub-ca.pem')]
+
+            }   
+           ]
 };
 
 exports.config = config;

--- a/proxy.js
+++ b/proxy.js
@@ -7,6 +7,7 @@
 */
 
 var http = require('http'),
+    https = require('https');
     util = require('util');
     fs   = require('fs'),
     config = require('./config').config,
@@ -356,8 +357,20 @@ update_blacklist();
 update_iplist();
 update_hostfilters();
 
+//http
 config.listen.forEach(function(listen){
   util.log("Starting reverse proxy server on port '" + listen.ip+':'+listen.port);
   http.createServer(server_cb).listen(listen.port, listen.ip); 
+});
+
+//httpS
+config.listen_ssl.forEach(function(listen){
+  util.log("Starting *secure* reverse proxy server on port '" + listen.ip+':'+listen.port);
+  var options = {
+    cert: listen.cert,
+    key: listen.key,
+    ca: listen.ca
+  }
+  https.createServer(options, server_cb).listen(listen.port, listen.ip); 
 });
 


### PR DESCRIPTION
Hi pkrumins !

Me again.  I added minimal https support in reverse proxy. It automatically encrypts all data between the client and the reverse proxy but does not try to reach the remote sever securely (yet).

As the server is initiated with the certificate attached on the IP and not on the VHOST, the certificate has to be valid for all reachable urls.

Hope you like it...
