### PR TITLE
Add missing comma in config object

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,7 +14,7 @@ var config = {
   black_list:    './config/black_list',
   host_filters:   './config/hostfilters.js',
   listen:[{ip:'0.0.0.0', port:80},//all ipv4 interfaces
-          {ip:'::', port:80}]//all ipv6 interfaces
+          {ip:'::', port:80}],//all ipv6 interfaces
   listen_ssl:[{
               ip:'0.0.0.0',//all *secure* ipv4 interfaces
               port:443,


### PR DESCRIPTION
Thanks for sharing this project!

My recent version of node.js threw a syntax error when I tried to run proxy.js
Error was caused by a missing comma on line 17 in config.js

Cheers
Greg
